### PR TITLE
Shorten Deployment Names Even Further

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calcualte-deployment-name",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "description": "Calculates valid deployment names based on repo name and branch name",
   "main": "lib/main.js",

--- a/src/calculate.ts
+++ b/src/calculate.ts
@@ -2,9 +2,9 @@ import {transliterate as tr, slugify} from 'transliteration'
 
 export default function calculate(appName: string, branchName: string): string {
   // we want to have a limit of max 52 characters for deployment name (dictated by the limit of some k8s services (like CronJobs))
-  // setting here to 48 to account for stage prefix ('stg-' or 'prd-')
+  // setting here to 47 to account for stage prefix ('stg-' or 'prd-')
   const deploymentName = slugify(
-    tr(`${appName.toLowerCase()}-${branchName.toLowerCase()}`.substring(0, 48)),
+    tr(`${appName.toLowerCase()}-${branchName.toLowerCase()}`.substring(0, 47)),
     {
       allowedChars: '-a-z0-9',
       trim: true

--- a/test/calculate.test.ts
+++ b/test/calculate.test.ts
@@ -12,12 +12,12 @@ describe('Calculate', () => {
     expect(result).toMatch(/^[^äö]+$/)
   })
 
-  it('shortens deployment names to 48 characters', () => {
+  it('shortens deployment names to 47 characters', () => {
     const result = calculate(
       'long app name',
       'dependabot/npm_and_yarn/typescript-eslint/eslint-plugin-4.17.0'
     )
-    expect(result.length).toBe(48)
+    expect(result.length).toBe(47)
   })
 
   describe('slugification', () => {


### PR DESCRIPTION
## Motivation
During deployment of publication-service-api we ran into the following error:
```
The CronJob "stg-publication-service-api-pro-2456-update-node-apps" is invalid: metadata.name: Invalid value: "stg-publication-service-api-pro-2456-update-node-apps": must be no more than 52 characters
```

...so we had to shorten deployment names by 1 more character.