### PR TITLE
v2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calcualte-deployment-name",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "calcualte-deployment-name",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calcualte-deployment-name",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "description": "Calculates valid deployment names based on repo name and branch name",
   "main": "lib/src/main.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,9 +7,9 @@ async function run(): Promise<void> {
     const branchName = core.getInput('branch')
     const deploymentName = calculate(appName, branchName)
 
-    core.debug('Successfully calculated deploymentName')
-    core.info(`Setting output 'name' to ${deploymentName}`)
-    core.setOutput('name', deploymentName)
+    core.debug('Successfully calculated deploymentName');
+    core.info(`Setting output 'name' to ${deploymentName}`);
+    core.exportVariable('DEPLOYMENT_NAME', deploymentName);
   } catch (error: unknown) {
     core.setFailed(error as Error)
   }


### PR DESCRIPTION
Switched to use `exportVariable` instead of `setOutput` for calculated deployment name.